### PR TITLE
Improve Rails 4.1 compatibility

### DIFF
--- a/lib/action_mailer/ar_sendmail.rb
+++ b/lib/action_mailer/ar_sendmail.rb
@@ -559,11 +559,8 @@ file already exists or the contents don't match it's PID.
 
     loop do
       now = Time.now
-      begin
-        cleanup
-        deliver find_emails
-      rescue ActiveRecord::Transactions::TransactionError
-      end
+      cleanup
+      deliver find_emails
       break if @once
       sleep @delay if now + @delay > Time.now
     end


### PR DESCRIPTION
`ActiveRecord::Transactions::TransactionError` was removed in Rails 4.1, and was last used in Rails 2.0.
